### PR TITLE
fixed f-string syntax mistake preventing bot from starting

### DIFF
--- a/chats.py
+++ b/chats.py
@@ -30,7 +30,7 @@ class ChatExporter:
 			should_export: bool = self._export_map.get(chat.type, False)
 			print(
 				f"Dialog: id={chat.id}, "
-				f"title={getattr(chat, "title", None) or getattr(chat, "first_name", None)}, "
+				f"title={getattr(chat, 'title', None) or getattr(chat, 'first_name', None)}, "
 				f"type={chat.type.name}, export={should_export}"
 			)
 			if should_export:


### PR DESCRIPTION
In the current version, line 33 in `chats.py` ( https://github.com/mo1ein/TelegramArchive/blob/main/chats.py#L33 ) contains a syntactic mistake, which causes SyntaxError and prevents the bot from starting. It's fixed in this pull request. 